### PR TITLE
Update image.py

### DIFF
--- a/mpfmc/widgets/image.py
+++ b/mpfmc/widgets/image.py
@@ -103,7 +103,7 @@ class ImageWidget(Widget):
         if self._image.image.anim_available:
             self.fps = self.config['fps']
             self.loops = self.config['loops']
-            self.start_frame = self._image.image.anim_index if self._image.frame_persist else self.config['start_frame']
+            self.start_frame = self._image.image.anim_index +1 if self._image.frame_persist else self.config['start_frame']
             # If not auto playing, set the end index to be the start frame
             if not self.config['auto_play']:
                 # Frame numbers start at 1 and indexes at 0, so subtract 1
@@ -111,7 +111,7 @@ class ImageWidget(Widget):
             self.play(start_frame=self.start_frame, auto_play=self.config['auto_play'])
 
             # If this image should persist its animation frame on future loads, set that now
-            if self._image.config.get('persist_frame'):
+            if self._image.config.get('frame_persist'):
                 self._image.frame_persist = True
 
     def _on_texture_change(self, *args) -> None:


### PR DESCRIPTION
Changed line 106 to include a +1 to make this sync with the rest of the code changed line 114 'persist_frame' to 'frame_persist' .  This makes only the reel that changes on a next ball advance rather than have all of the player's score reels advance on the next ball.  For example with this change 1410 goes to 1510 on a score of 100 on the next ball rather than 1400 -> 1000 -> 1110 -> 1210 -> 1310 -> 1410 -> 1510.